### PR TITLE
Implement user CRUD service and auth endpoints

### DIFF
--- a/backend/handlers/auth.py
+++ b/backend/handlers/auth.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import UserService
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=schema.User, status_code=status.HTTP_201_CREATED)
+def register_user(user_in: schema.UserCreate, db: Session = Depends(get_db)) -> schema.User:
+    service = UserService(db)
+
+    existing_user = service.get_user_by_name(user_in.name)
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
+
+    user = service.create_user(user_in)
+    return schema.User.model_validate(user)
+
+
+@router.post("/login", response_model=schema.User)
+def login_user(credentials: schema.UserLogin, db: Session = Depends(get_db)) -> schema.User:
+    service = UserService(db)
+
+    user = service.authenticate(credentials.name, credentials.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    return schema.User.model_validate(user)
+
+
+@router.post("/forgot-password", response_model=schema.User)
+def forgot_password(payload: schema.PasswordResetRequest, db: Session = Depends(get_db)) -> schema.User:
+    service = UserService(db)
+
+    user = service.get_user_by_name(payload.name)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    updated_user = service.update_password(user.user_id, payload.new_password)
+    if not updated_user:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Unable to update password")
+
+    return schema.User.model_validate(updated_user)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from fastapi import FastAPI
+
+from backend.handlers.auth import router as auth_router
+from backend.service.db.db import create_tables
+
+create_tables()
+
+app = FastAPI(title="User Service API")
+app.include_router(auth_router)
+
+
+@app.get("/")
+def read_root() -> Dict[str, str]:
+    return {"status": "ok"}

--- a/backend/service/db/schema.py
+++ b/backend/service/db/schema.py
@@ -148,3 +148,13 @@ class Status(StatusBase):
     status_id: int
 
     model_config = ConfigDict(from_attributes=True)
+
+class UserLogin(BaseModel):
+    name: str
+    password: str
+
+
+class PasswordResetRequest(BaseModel):
+    name: str
+    new_password: str
+

--- a/backend/service/db/service.py
+++ b/backend/service/db/service.py
@@ -1,0 +1,83 @@
+from typing import List, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.service.db import model, schema
+
+
+class UserService:
+    """Service layer for CRUD operations on :class:`model.User`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_user(self, user_in: schema.UserCreate) -> model.User:
+        """Create a new user in the database."""
+        user = model.User(
+            name=user_in.name,
+            password=user_in.password,
+            role=model.RoleEnum(user_in.role.value),
+        )
+        self._session.add(user)
+        try:
+            self._session.commit()
+        except IntegrityError:
+            self._session.rollback()
+            raise
+        self._session.refresh(user)
+        return user
+
+    def list_users(self) -> List[model.User]:
+        """Return all users."""
+        return self._session.query(model.User).all()
+
+    def get_user_by_id(self, user_id: int) -> Optional[model.User]:
+        """Return a user by its ID."""
+        return self._session.query(model.User).filter(model.User.user_id == user_id).first()
+
+    def get_user_by_name(self, name: str) -> Optional[model.User]:
+        """Return a user by its name."""
+        return self._session.query(model.User).filter(model.User.name == name).first()
+
+    def update_user(self, user_id: int, user_in: schema.UserBase) -> Optional[model.User]:
+        """Update user fields."""
+        user = self.get_user_by_id(user_id)
+        if not user:
+            return None
+
+        user.name = user_in.name
+        user.password = user_in.password
+        user.role = model.RoleEnum(user_in.role.value)
+        self._session.add(user)
+        self._session.commit()
+        self._session.refresh(user)
+        return user
+
+    def update_password(self, user_id: int, new_password: str) -> Optional[model.User]:
+        """Update password for a user."""
+        user = self.get_user_by_id(user_id)
+        if not user:
+            return None
+
+        user.password = new_password
+        self._session.add(user)
+        self._session.commit()
+        self._session.refresh(user)
+        return user
+
+    def delete_user(self, user_id: int) -> bool:
+        """Delete a user by its ID."""
+        user = self.get_user_by_id(user_id)
+        if not user:
+            return False
+        self._session.delete(user)
+        self._session.commit()
+        return True
+
+    def authenticate(self, name: str, password: str) -> Optional[model.User]:
+        """Validate user credentials."""
+        user = self.get_user_by_name(name)
+        if user and user.password == password:
+            return user
+        return None


### PR DESCRIPTION
## Summary
- add a SQLAlchemy-backed `UserService` with CRUD helpers and authentication logic
- implement FastAPI auth handlers for user registration, login, and password reset
- configure the FastAPI application and extend Pydantic schemas for auth payloads

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_b_68d2f049d2b08327b463817d12f37934