### PR TITLE
Add CRUD services and API routers for domain tables

### DIFF
--- a/backend/handlers/checks.py
+++ b/backend/handlers/checks.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import CheckService
+
+router = APIRouter(prefix="/checks", tags=["checks"])
+
+
+@router.post("/", response_model=schema.Check, status_code=status.HTTP_201_CREATED)
+def create_check(
+    check_in: schema.CheckCreate, db: Session = Depends(get_db)
+) -> schema.Check:
+    service = CheckService(db)
+    check = service.create_check(check_in)
+    return schema.Check.model_validate(check)
+
+
+@router.get("/", response_model=List[schema.Check])
+def list_checks(db: Session = Depends(get_db)) -> List[schema.Check]:
+    service = CheckService(db)
+    checks = service.list_checks()
+    return [schema.Check.model_validate(item) for item in checks]
+
+
+@router.get("/{check_id}", response_model=schema.Check)
+def get_check(check_id: int, db: Session = Depends(get_db)) -> schema.Check:
+    service = CheckService(db)
+    check = service.get_check(check_id)
+    if not check:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Check not found")
+    return schema.Check.model_validate(check)
+
+
+@router.put("/{check_id}", response_model=schema.Check)
+def update_check(
+    check_id: int, check_in: schema.CheckBase, db: Session = Depends(get_db)
+) -> schema.Check:
+    service = CheckService(db)
+    check = service.update_check(check_id, check_in)
+    if not check:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Check not found")
+    return schema.Check.model_validate(check)
+
+
+@router.delete("/{check_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_check(check_id: int, db: Session = Depends(get_db)) -> None:
+    service = CheckService(db)
+    deleted = service.delete_check(check_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Check not found")
+

--- a/backend/handlers/documents.py
+++ b/backend/handlers/documents.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import DocumentService
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+@router.post("/", response_model=schema.Document, status_code=status.HTTP_201_CREATED)
+def create_document(
+    document_in: schema.DocumentCreate, db: Session = Depends(get_db)
+) -> schema.Document:
+    service = DocumentService(db)
+    document = service.create_document(document_in)
+    return schema.Document.model_validate(document)
+
+
+@router.get("/", response_model=List[schema.Document])
+def list_documents(db: Session = Depends(get_db)) -> List[schema.Document]:
+    service = DocumentService(db)
+    documents = service.list_documents()
+    return [schema.Document.model_validate(item) for item in documents]
+
+
+@router.get("/{document_id}", response_model=schema.Document)
+def get_document(document_id: int, db: Session = Depends(get_db)) -> schema.Document:
+    service = DocumentService(db)
+    document = service.get_document(document_id)
+    if not document:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+    return schema.Document.model_validate(document)
+
+
+@router.put("/{document_id}", response_model=schema.Document)
+def update_document(
+    document_id: int, document_in: schema.DocumentBase, db: Session = Depends(get_db)
+) -> schema.Document:
+    service = DocumentService(db)
+    document = service.update_document(document_id, document_in)
+    if not document:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+    return schema.Document.model_validate(document)
+
+
+@router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_document(document_id: int, db: Session = Depends(get_db)) -> None:
+    service = DocumentService(db)
+    deleted = service.delete_document(document_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
+

--- a/backend/handlers/incidents.py
+++ b/backend/handlers/incidents.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import IncidentService
+
+router = APIRouter(prefix="/incidents", tags=["incidents"])
+
+
+@router.post("/", response_model=schema.Incident, status_code=status.HTTP_201_CREATED)
+def create_incident(
+    incident_in: schema.IncidentCreate, db: Session = Depends(get_db)
+) -> schema.Incident:
+    service = IncidentService(db)
+    incident = service.create_incident(incident_in)
+    return schema.Incident.model_validate(incident)
+
+
+@router.get("/", response_model=List[schema.Incident])
+def list_incidents(db: Session = Depends(get_db)) -> List[schema.Incident]:
+    service = IncidentService(db)
+    incidents = service.list_incidents()
+    return [schema.Incident.model_validate(item) for item in incidents]
+
+
+@router.get("/{incident_id}", response_model=schema.Incident)
+def get_incident(incident_id: int, db: Session = Depends(get_db)) -> schema.Incident:
+    service = IncidentService(db)
+    incident = service.get_incident(incident_id)
+    if not incident:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Incident not found")
+    return schema.Incident.model_validate(incident)
+
+
+@router.put("/{incident_id}", response_model=schema.Incident)
+def update_incident(
+    incident_id: int, incident_in: schema.IncidentBase, db: Session = Depends(get_db)
+) -> schema.Incident:
+    service = IncidentService(db)
+    incident = service.update_incident(incident_id, incident_in)
+    if not incident:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Incident not found")
+    return schema.Incident.model_validate(incident)
+
+
+@router.delete("/{incident_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_incident(incident_id: int, db: Session = Depends(get_db)) -> None:
+    service = IncidentService(db)
+    deleted = service.delete_incident(incident_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Incident not found")
+

--- a/backend/handlers/materials.py
+++ b/backend/handlers/materials.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import MaterialService
+
+router = APIRouter(prefix="/materials", tags=["materials"])
+
+
+@router.post("/", response_model=schema.Material, status_code=status.HTTP_201_CREATED)
+def create_material(
+    material_in: schema.MaterialCreate, db: Session = Depends(get_db)
+) -> schema.Material:
+    service = MaterialService(db)
+    material = service.create_material(material_in)
+    return schema.Material.model_validate(material)
+
+
+@router.get("/", response_model=List[schema.Material])
+def list_materials(db: Session = Depends(get_db)) -> List[schema.Material]:
+    service = MaterialService(db)
+    materials = service.list_materials()
+    return [schema.Material.model_validate(item) for item in materials]
+
+
+@router.get("/{material_id}", response_model=schema.Material)
+def get_material(material_id: int, db: Session = Depends(get_db)) -> schema.Material:
+    service = MaterialService(db)
+    material = service.get_material(material_id)
+    if not material:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Material not found")
+    return schema.Material.model_validate(material)
+
+
+@router.put("/{material_id}", response_model=schema.Material)
+def update_material(
+    material_id: int, material_in: schema.MaterialBase, db: Session = Depends(get_db)
+) -> schema.Material:
+    service = MaterialService(db)
+    material = service.update_material(material_id, material_in)
+    if not material:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Material not found")
+    return schema.Material.model_validate(material)
+
+
+@router.delete("/{material_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_material(material_id: int, db: Session = Depends(get_db)) -> None:
+    service = MaterialService(db)
+    deleted = service.delete_material(material_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Material not found")
+

--- a/backend/handlers/objects.py
+++ b/backend/handlers/objects.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import ObjectService
+
+router = APIRouter(prefix="/objects", tags=["objects"])
+
+
+@router.post("/", response_model=schema.Object, status_code=status.HTTP_201_CREATED)
+def create_object(
+    object_in: schema.ObjectCreate, db: Session = Depends(get_db)
+) -> schema.Object:
+    service = ObjectService(db)
+    obj = service.create_object(object_in)
+    return schema.Object.model_validate(obj)
+
+
+@router.get("/", response_model=List[schema.Object])
+def list_objects(db: Session = Depends(get_db)) -> List[schema.Object]:
+    service = ObjectService(db)
+    objects = service.list_objects()
+    return [schema.Object.model_validate(obj) for obj in objects]
+
+
+@router.get("/{object_id}", response_model=schema.Object)
+def get_object(object_id: int, db: Session = Depends(get_db)) -> schema.Object:
+    service = ObjectService(db)
+    obj = service.get_object(object_id)
+    if not obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Object not found")
+    return schema.Object.model_validate(obj)
+
+
+@router.put("/{object_id}", response_model=schema.Object)
+def update_object(
+    object_id: int, object_in: schema.ObjectCreate, db: Session = Depends(get_db)
+) -> schema.Object:
+    service = ObjectService(db)
+    obj = service.update_object(object_id, object_in)
+    if not obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Object not found")
+    return schema.Object.model_validate(obj)
+
+
+@router.delete("/{object_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_object(object_id: int, db: Session = Depends(get_db)) -> None:
+    service = ObjectService(db)
+    deleted = service.delete_object(object_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Object not found")
+

--- a/backend/handlers/statuses.py
+++ b/backend/handlers/statuses.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import StatusService
+
+router = APIRouter(prefix="/statuses", tags=["statuses"])
+
+
+@router.post("/", response_model=schema.Status, status_code=status.HTTP_201_CREATED)
+def create_status(
+    status_in: schema.StatusCreate, db: Session = Depends(get_db)
+) -> schema.Status:
+    service = StatusService(db)
+    status_obj = service.create_status(status_in)
+    return schema.Status.model_validate(status_obj)
+
+
+@router.get("/", response_model=List[schema.Status])
+def list_statuses(db: Session = Depends(get_db)) -> List[schema.Status]:
+    service = StatusService(db)
+    statuses = service.list_statuses()
+    return [schema.Status.model_validate(item) for item in statuses]
+
+
+@router.get("/{status_id}", response_model=schema.Status)
+def get_status(status_id: int, db: Session = Depends(get_db)) -> schema.Status:
+    service = StatusService(db)
+    status_obj = service.get_status(status_id)
+    if not status_obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Status not found")
+    return schema.Status.model_validate(status_obj)
+
+
+@router.put("/{status_id}", response_model=schema.Status)
+def update_status(
+    status_id: int, status_in: schema.StatusBase, db: Session = Depends(get_db)
+) -> schema.Status:
+    service = StatusService(db)
+    status_obj = service.update_status(status_id, status_in)
+    if not status_obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Status not found")
+    return schema.Status.model_validate(status_obj)
+
+
+@router.delete("/{status_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_status(status_id: int, db: Session = Depends(get_db)) -> None:
+    service = StatusService(db)
+    deleted = service.delete_status(status_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Status not found")
+

--- a/backend/handlers/subobjects.py
+++ b/backend/handlers/subobjects.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.service.db import schema
+from backend.service.db.db import get_db
+from backend.service.db.service import SubObjectService
+
+router = APIRouter(prefix="/subobjects", tags=["subobjects"])
+
+
+@router.post("/", response_model=schema.SubObject, status_code=status.HTTP_201_CREATED)
+def create_subobject(
+    subobject_in: schema.SubObjectCreate, db: Session = Depends(get_db)
+) -> schema.SubObject:
+    service = SubObjectService(db)
+    subobject = service.create_subobject(subobject_in)
+    return schema.SubObject.model_validate(subobject)
+
+
+@router.get("/", response_model=List[schema.SubObject])
+def list_subobjects(db: Session = Depends(get_db)) -> List[schema.SubObject]:
+    service = SubObjectService(db)
+    subobjects = service.list_subobjects()
+    return [schema.SubObject.model_validate(item) for item in subobjects]
+
+
+@router.get("/{subobject_id}", response_model=schema.SubObject)
+def get_subobject(subobject_id: int, db: Session = Depends(get_db)) -> schema.SubObject:
+    service = SubObjectService(db)
+    subobject = service.get_subobject(subobject_id)
+    if not subobject:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
+    return schema.SubObject.model_validate(subobject)
+
+
+@router.put("/{subobject_id}", response_model=schema.SubObject)
+def update_subobject(
+    subobject_id: int, subobject_in: schema.SubObjectBase, db: Session = Depends(get_db)
+) -> schema.SubObject:
+    service = SubObjectService(db)
+    subobject = service.update_subobject(subobject_id, subobject_in)
+    if not subobject:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
+    return schema.SubObject.model_validate(subobject)
+
+
+@router.delete("/{subobject_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_subobject(subobject_id: int, db: Session = Depends(get_db)) -> None:
+    service = SubObjectService(db)
+    deleted = service.delete_subobject(subobject_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,12 +3,26 @@ from typing import Dict
 from fastapi import FastAPI
 
 from backend.handlers.auth import router as auth_router
+from backend.handlers.checks import router as checks_router
+from backend.handlers.documents import router as documents_router
+from backend.handlers.incidents import router as incidents_router
+from backend.handlers.materials import router as materials_router
+from backend.handlers.objects import router as objects_router
+from backend.handlers.statuses import router as statuses_router
+from backend.handlers.subobjects import router as subobjects_router
 from backend.service.db.db import create_tables
 
 create_tables()
 
 app = FastAPI(title="User Service API")
 app.include_router(auth_router)
+app.include_router(objects_router)
+app.include_router(subobjects_router)
+app.include_router(checks_router)
+app.include_router(incidents_router)
+app.include_router(documents_router)
+app.include_router(materials_router)
+app.include_router(statuses_router)
 
 
 @app.get("/")

--- a/backend/service/db/schema.py
+++ b/backend/service/db/schema.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, ConfigDict
-from datetime import datetime
-from typing import Optional, Dict, Any
+from datetime import datetime, date
+from typing import Optional
 from enum import Enum
 
 
@@ -70,9 +70,8 @@ class SubObject(SubObjectBase):
 
 
 class CheckBase(BaseModel):
-    phone: Optional[str] = None
     photo: Optional[str] = None
-    location: Optional[Dict[str, Any]] = None
+    location: Optional[str] = None
     info: Optional[str] = None
 
 
@@ -90,6 +89,7 @@ class Check(CheckBase):
 
 class IncidentBase(BaseModel):
     info: str
+    photo: Optional[str] = None
 
 
 class IncidentCreate(IncidentBase):
@@ -106,6 +106,7 @@ class Incident(IncidentBase):
 
 class DocumentBase(BaseModel):
     file_id: str
+    doc_date: Optional[date] = None
 
 
 class DocumentCreate(DocumentBase):
@@ -114,14 +115,13 @@ class DocumentCreate(DocumentBase):
 
 class Document(DocumentBase):
     document_id: int
-    date: datetime
     check_id: int
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class MaterialBase(BaseModel):
-    tm_id: Optional[int] = None
+    ttn_id: Optional[int] = None
     parsed_data: Optional[str] = None
 
 

--- a/backend/service/db/service.py
+++ b/backend/service/db/service.py
@@ -81,3 +81,387 @@ class UserService:
         if user and user.password == password:
             return user
         return None
+
+
+class ObjectService:
+    """Service layer for CRUD operations on :class:`model.Object`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_object(self, object_in: schema.ObjectCreate) -> model.Object:
+        obj = model.Object(
+            name=object_in.name,
+            status=object_in.status,
+            inspection_id=object_in.inspection_id,
+            contractor_id=object_in.contractor_id,
+        )
+        self._session.add(obj)
+        self._session.commit()
+        self._session.refresh(obj)
+        return obj
+
+    def list_objects(self) -> List[model.Object]:
+        return self._session.query(model.Object).all()
+
+    def get_object(self, object_id: int) -> Optional[model.Object]:
+        return (
+            self._session.query(model.Object)
+            .filter(model.Object.object_id == object_id)
+            .first()
+        )
+
+    def update_object(
+        self, object_id: int, object_in: schema.ObjectCreate
+    ) -> Optional[model.Object]:
+        obj = self.get_object(object_id)
+        if not obj:
+            return None
+
+        obj.name = object_in.name
+        obj.status = object_in.status
+        obj.inspection_id = object_in.inspection_id
+        obj.contractor_id = object_in.contractor_id
+        self._session.add(obj)
+        self._session.commit()
+        self._session.refresh(obj)
+        return obj
+
+    def delete_object(self, object_id: int) -> bool:
+        obj = self.get_object(object_id)
+        if not obj:
+            return False
+        self._session.delete(obj)
+        self._session.commit()
+        return True
+
+
+class SubObjectService:
+    """Service layer for CRUD operations on :class:`model.SubObject`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_subobject(self, subobject_in: schema.SubObjectCreate) -> model.SubObject:
+        subobject = model.SubObject(
+            name=subobject_in.name,
+            object_id=subobject_in.object_id,
+            status_inspector=
+            (
+                model.StatusEnum(subobject_in.status_inspector.value)
+                if subobject_in.status_inspector
+                else None
+            ),
+            status_contractor=
+            (
+                model.StatusEnum(subobject_in.status_contractor.value)
+                if subobject_in.status_contractor
+                else None
+            ),
+            status_admin=
+            (
+                model.StatusEnum(subobject_in.status_admin.value)
+                if subobject_in.status_admin
+                else None
+            ),
+        )
+        self._session.add(subobject)
+        self._session.commit()
+        self._session.refresh(subobject)
+        return subobject
+
+    def list_subobjects(self) -> List[model.SubObject]:
+        return self._session.query(model.SubObject).all()
+
+    def get_subobject(self, subobject_id: int) -> Optional[model.SubObject]:
+        return (
+            self._session.query(model.SubObject)
+            .filter(model.SubObject.subobject_id == subobject_id)
+            .first()
+        )
+
+    def update_subobject(
+        self, subobject_id: int, subobject_in: schema.SubObjectBase
+    ) -> Optional[model.SubObject]:
+        subobject = self.get_subobject(subobject_id)
+        if not subobject:
+            return None
+
+        subobject.name = subobject_in.name
+        subobject.status_inspector = (
+            model.StatusEnum(subobject_in.status_inspector.value)
+            if subobject_in.status_inspector
+            else None
+        )
+        subobject.status_contractor = (
+            model.StatusEnum(subobject_in.status_contractor.value)
+            if subobject_in.status_contractor
+            else None
+        )
+        subobject.status_admin = (
+            model.StatusEnum(subobject_in.status_admin.value)
+            if subobject_in.status_admin
+            else None
+        )
+        self._session.add(subobject)
+        self._session.commit()
+        self._session.refresh(subobject)
+        return subobject
+
+    def delete_subobject(self, subobject_id: int) -> bool:
+        subobject = self.get_subobject(subobject_id)
+        if not subobject:
+            return False
+        self._session.delete(subobject)
+        self._session.commit()
+        return True
+
+
+class CheckService:
+    """Service layer for CRUD operations on :class:`model.Check`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_check(self, check_in: schema.CheckCreate) -> model.Check:
+        check = model.Check(
+            subobject_id=check_in.subobject_id,
+            photo=check_in.photo,
+            location=check_in.location,
+            info=check_in.info,
+        )
+        self._session.add(check)
+        self._session.commit()
+        self._session.refresh(check)
+        return check
+
+    def list_checks(self) -> List[model.Check]:
+        return self._session.query(model.Check).all()
+
+    def get_check(self, check_id: int) -> Optional[model.Check]:
+        return (
+            self._session.query(model.Check)
+            .filter(model.Check.check_id == check_id)
+            .first()
+        )
+
+    def update_check(
+        self, check_id: int, check_in: schema.CheckBase
+    ) -> Optional[model.Check]:
+        check = self.get_check(check_id)
+        if not check:
+            return None
+
+        check.photo = check_in.photo
+        check.location = check_in.location
+        check.info = check_in.info
+        self._session.add(check)
+        self._session.commit()
+        self._session.refresh(check)
+        return check
+
+    def delete_check(self, check_id: int) -> bool:
+        check = self.get_check(check_id)
+        if not check:
+            return False
+        self._session.delete(check)
+        self._session.commit()
+        return True
+
+
+class IncidentService:
+    """Service layer for CRUD operations on :class:`model.Incident`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_incident(self, incident_in: schema.IncidentCreate) -> model.Incident:
+        incident = model.Incident(
+            check_id=incident_in.check_id,
+            info=incident_in.info,
+            photo=incident_in.photo,
+        )
+        self._session.add(incident)
+        self._session.commit()
+        self._session.refresh(incident)
+        return incident
+
+    def list_incidents(self) -> List[model.Incident]:
+        return self._session.query(model.Incident).all()
+
+    def get_incident(self, incident_id: int) -> Optional[model.Incident]:
+        return (
+            self._session.query(model.Incident)
+            .filter(model.Incident.incident_id == incident_id)
+            .first()
+        )
+
+    def update_incident(
+        self, incident_id: int, incident_in: schema.IncidentBase
+    ) -> Optional[model.Incident]:
+        incident = self.get_incident(incident_id)
+        if not incident:
+            return None
+
+        incident.info = incident_in.info
+        incident.photo = incident_in.photo
+        self._session.add(incident)
+        self._session.commit()
+        self._session.refresh(incident)
+        return incident
+
+    def delete_incident(self, incident_id: int) -> bool:
+        incident = self.get_incident(incident_id)
+        if not incident:
+            return False
+        self._session.delete(incident)
+        self._session.commit()
+        return True
+
+
+class DocumentService:
+    """Service layer for CRUD operations on :class:`model.Document`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_document(self, document_in: schema.DocumentCreate) -> model.Document:
+        document = model.Document(
+            check_id=document_in.check_id,
+            file_id=document_in.file_id,
+            doc_date=document_in.doc_date,
+        )
+        self._session.add(document)
+        self._session.commit()
+        self._session.refresh(document)
+        return document
+
+    def list_documents(self) -> List[model.Document]:
+        return self._session.query(model.Document).all()
+
+    def get_document(self, document_id: int) -> Optional[model.Document]:
+        return (
+            self._session.query(model.Document)
+            .filter(model.Document.document_id == document_id)
+            .first()
+        )
+
+    def update_document(
+        self, document_id: int, document_in: schema.DocumentBase
+    ) -> Optional[model.Document]:
+        document = self.get_document(document_id)
+        if not document:
+            return None
+
+        document.file_id = document_in.file_id
+        document.doc_date = document_in.doc_date
+        self._session.add(document)
+        self._session.commit()
+        self._session.refresh(document)
+        return document
+
+    def delete_document(self, document_id: int) -> bool:
+        document = self.get_document(document_id)
+        if not document:
+            return False
+        self._session.delete(document)
+        self._session.commit()
+        return True
+
+
+class MaterialService:
+    """Service layer for CRUD operations on :class:`model.Material`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_material(self, material_in: schema.MaterialCreate) -> model.Material:
+        material = model.Material(
+            ttn_id=material_in.ttn_id,
+            parsed_data=material_in.parsed_data,
+        )
+        self._session.add(material)
+        self._session.commit()
+        self._session.refresh(material)
+        return material
+
+    def list_materials(self) -> List[model.Material]:
+        return self._session.query(model.Material).all()
+
+    def get_material(self, material_id: int) -> Optional[model.Material]:
+        return (
+            self._session.query(model.Material)
+            .filter(model.Material.material_id == material_id)
+            .first()
+        )
+
+    def update_material(
+        self, material_id: int, material_in: schema.MaterialBase
+    ) -> Optional[model.Material]:
+        material = self.get_material(material_id)
+        if not material:
+            return None
+
+        material.ttn_id = material_in.ttn_id
+        material.parsed_data = material_in.parsed_data
+        self._session.add(material)
+        self._session.commit()
+        self._session.refresh(material)
+        return material
+
+    def delete_material(self, material_id: int) -> bool:
+        material = self.get_material(material_id)
+        if not material:
+            return False
+        self._session.delete(material)
+        self._session.commit()
+        return True
+
+
+class StatusService:
+    """Service layer for CRUD operations on :class:`model.Status`."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create_status(self, status_in: schema.StatusCreate) -> model.Status:
+        status = model.Status(
+            status=model.StatusEnum(status_in.status.value),
+            info=status_in.info,
+        )
+        self._session.add(status)
+        self._session.commit()
+        self._session.refresh(status)
+        return status
+
+    def list_statuses(self) -> List[model.Status]:
+        return self._session.query(model.Status).all()
+
+    def get_status(self, status_id: int) -> Optional[model.Status]:
+        return (
+            self._session.query(model.Status)
+            .filter(model.Status.status_id == status_id)
+            .first()
+        )
+
+    def update_status(
+        self, status_id: int, status_in: schema.StatusBase
+    ) -> Optional[model.Status]:
+        status = self.get_status(status_id)
+        if not status:
+            return None
+
+        status.status = model.StatusEnum(status_in.status.value)
+        status.info = status_in.info
+        self._session.add(status)
+        self._session.commit()
+        self._session.refresh(status)
+        return status
+
+    def delete_status(self, status_id: int) -> bool:
+        status = self.get_status(status_id)
+        if not status:
+            return False
+        self._session.delete(status)
+        self._session.commit()
+        return True


### PR DESCRIPTION
## Summary
- align pydantic schemas with ORM models for checks, documents, materials, and incidents
- add service-layer CRUD helpers for objects, subobjects, checks, incidents, documents, materials, and statuses
- expose FastAPI routers for each domain entity and register them in the application

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_b_68d2feffbadc8327903d361820c27e16