### PR TITLE
Add inspection linkage support to objects

### DIFF
--- a/backend/service/db/model.py
+++ b/backend/service/db/model.py
@@ -59,6 +59,7 @@ class Object(Base):
     admin_id = Column(Integer, ForeignKey("USER.user_id"))
     inspector_id = Column(Integer, ForeignKey("USER.user_id"))
     contractor_id = Column(Integer, ForeignKey("USER.user_id"))
+    inspection_id = Column(Integer, nullable=True)
     status = Column(String(50))
     address = Column(String(300))
 

--- a/backend/service/db/schema.py
+++ b/backend/service/db/schema.py
@@ -86,6 +86,7 @@ class ObjectBase(BaseModel):
     name: str
     status: Optional[str] = None
     address: Optional[str] = None
+    inspection_id: Optional[int] = None
 
 
 class ObjectCreate(ObjectBase):
@@ -230,6 +231,7 @@ class ObjectUpdate(BaseModel):
     contractor_id: Optional[int] = None
     status: Optional[str] = None
     address: Optional[str] = None
+    inspection_id: Optional[int] = None
 
 
 class SubObjectUpdate(BaseModel):

--- a/backend/service/db/service.py
+++ b/backend/service/db/service.py
@@ -98,6 +98,7 @@ class ObjectService:
             admin_id=object_in.admin_id,
             inspector_id=object_in.inspector_id,
             contractor_id=object_in.contractor_id,
+            inspection_id=object_in.inspection_id,
             status=object_in.status,
             address=object_in.address,
         )
@@ -131,6 +132,8 @@ class ObjectService:
             obj.inspector_id = object_in.inspector_id
         if object_in.contractor_id is not None:
             obj.contractor_id = object_in.contractor_id
+        if object_in.inspection_id is not None:
+            obj.inspection_id = object_in.inspection_id
         if object_in.status is not None:
             obj.status = object_in.status
         if object_in.address is not None:


### PR DESCRIPTION
## Summary
- add an optional `inspection_id` column to the SQLAlchemy Object model so it can persist incoming data
- expose `inspection_id` through the Pydantic schemas and make the service propagate it on create/update

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d7c77de15c8327b6f9d9f3c70de352