### PR TITLE
Add role-based restrictions to object and subobject endpoints

### DIFF
--- a/backend/handlers/subobjects.py
+++ b/backend/handlers/subobjects.py
@@ -1,11 +1,12 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from service.db import schema
 from service.db.db import get_db
-from service.db.service import SubObjectService
+from service.db.service import ObjectService, SubObjectService
+from service.auth import get_current_user
 
 router = APIRouter(prefix="/subobjects", tags=["subobjects"])
 
@@ -16,26 +17,63 @@ def create_subobject(
 ) -> schema.SubObject:
     # может создать только админ, если кто то другой - недостаточность прав
     # нужно проверить существует ли object_id - если нет - возвращаем нот фоунд
+    current_user = get_current_user()
+    if current_user.role is not schema.RoleEnum.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
+
+    object_service = ObjectService(db)
+    if not object_service.get_object(subobject_in.object_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Object not found"
+        )
+
     service = SubObjectService(db)
     subobject = service.create_subobject(subobject_in)
     return schema.SubObject.model_validate(subobject)
 
 
 @router.get("/", response_model=List[schema.SubObject])
-def list_subobjects(db: Session = Depends(get_db)) -> List[schema.SubObject]:
+def list_subobjects(
+    db: Session = Depends(get_db),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+) -> List[schema.SubObject]:
     # Ситуация как в объекте - возвращем админу все с оффсетом и лимитом, остальным только их проекты
+    current_user = get_current_user()
     service = SubObjectService(db)
-    subobjects = service.list_subobjects()
+    subobjects = service.list_subobjects(
+        limit=limit, offset=offset, role=current_user.role, user_id=current_user.user_id
+    )
     return [schema.SubObject.model_validate(item) for item in subobjects]
 
 
 @router.get("/{subobject_id}", response_model=schema.SubObject)
 def get_subobject(subobject_id: int, db: Session = Depends(get_db)) -> schema.SubObject:
     # так же как в объекте
+    current_user = get_current_user()
     service = SubObjectService(db)
     subobject = service.get_subobject(subobject_id)
     if not subobject:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
+    if current_user.role in (schema.RoleEnum.INSPECTOR, schema.RoleEnum.CONTRACTOR):
+        object_service = ObjectService(db)
+        parent_object = object_service.get_object(subobject.object_id)
+        if not parent_object:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Object not found"
+            )
+        if (
+            current_user.role == schema.RoleEnum.INSPECTOR
+            and parent_object.inspector_id != current_user.user_id
+        ) or (
+            current_user.role == schema.RoleEnum.CONTRACTOR
+            and parent_object.contractor_id != current_user.user_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
     return schema.SubObject.model_validate(subobject)
 
 
@@ -47,7 +85,64 @@ def update_subobject(
     # статус админ если мелькает от инспектора - возвращаем отсутствие прав
     # апдейтить может и конструктор - только свой статус, если он пытается обновить статус у других ролей - возвращаем
     # недостаточность прав
+    current_user = get_current_user()
+    allowed_fields = set()
+
+    if current_user.role == schema.RoleEnum.ADMIN:
+        allowed_fields = {
+            "name",
+            "status_inspector",
+            "status_contractor",
+            "status_admin",
+            "prescription_info",
+            "object_id",
+        }
+    elif current_user.role == schema.RoleEnum.INSPECTOR:
+        allowed_fields = {"status_inspector"}
+    elif current_user.role == schema.RoleEnum.CONTRACTOR:
+        allowed_fields = {"status_contractor"}
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
+
+    requested_fields = set(subobject_in.model_fields_set)
+    if requested_fields and not requested_fields.issubset(allowed_fields):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions to update requested fields",
+        )
+
     service = SubObjectService(db)
+    existing_subobject = service.get_subobject(subobject_id)
+    if not existing_subobject:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
+
+    if current_user.role in (schema.RoleEnum.INSPECTOR, schema.RoleEnum.CONTRACTOR):
+        object_service = ObjectService(db)
+        parent_object = object_service.get_object(existing_subobject.object_id)
+        if not parent_object:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Object not found"
+            )
+        if (
+            current_user.role == schema.RoleEnum.INSPECTOR
+            and parent_object.inspector_id != current_user.user_id
+        ) or (
+            current_user.role == schema.RoleEnum.CONTRACTOR
+            and parent_object.contractor_id != current_user.user_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+            )
+
+    if "object_id" in requested_fields:
+        object_service = ObjectService(db)
+        if not object_service.get_object(subobject_in.object_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Object not found"
+            )
+
     subobject = service.update_subobject(subobject_id, subobject_in)
     if not subobject:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subobject not found")
@@ -57,6 +152,11 @@ def update_subobject(
 @router.delete("/{subobject_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_subobject(subobject_id: int, db: Session = Depends(get_db)) -> None:
     # так же как в объекте - удалять может только админ
+    current_user = get_current_user()
+    if current_user.role is not schema.RoleEnum.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
     service = SubObjectService(db)
     deleted = service.delete_subobject(subobject_id)
     if not deleted:

--- a/backend/service/auth.py
+++ b/backend/service/auth.py
@@ -1,0 +1,12 @@
+from service.db import schema
+
+
+def get_current_user() -> schema.User:
+    """Return the current authenticated user.
+
+    This is a temporary stub that always returns an admin user. It should be
+    replaced with real authentication that extracts the user information from
+    Keycloak tokens.
+    """
+
+    return schema.User(user_id=1, name="Admin", role=schema.RoleEnum.ADMIN)


### PR DESCRIPTION
## Summary
- add a temporary authentication stub that returns an admin user until Keycloak integration is ready
- enforce role-based permissions and related validation in object and subobject handlers, including pagination support
- update database services to paginate and scope object/subobject queries by the caller role

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_b_68d7d1ec136883278bc99369103d2eec