### PR TITLE
Add mock photo processing endpoint for others tag

### DIFF
--- a/backend/handlers/others.py
+++ b/backend/handlers/others.py
@@ -1,0 +1,68 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy.orm import Session
+
+from service.db import schema
+from service.db.db import get_db
+from service.db.service import DocumentService, MaterialService
+from service.others.photo_client import analyze_photo
+
+router = APIRouter(prefix="/others", tags=["others"])
+
+
+@router.post(
+    "/process-photo",
+    response_model=schema.PhotoProcessingResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def process_photo(
+    user_id: int = Form(...),
+    object_id: int = Form(...),
+    photo: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> schema.PhotoProcessingResponse:
+    """Accept a photo, forward it to the external service and persist the results."""
+
+    if photo.content_type not in {"image/jpeg", "image/png", "image/jpg"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported file type. Only JPEG and PNG are allowed.",
+        )
+
+    image_bytes = await photo.read()
+    document_data, materials_data = analyze_photo(image_bytes)
+
+    document_service = DocumentService(db)
+    material_service = MaterialService(db)
+
+    document_create = schema.DocumentCreate(
+        user_id=user_id,
+        object_id=object_id,
+        doc_type=document_data.doc_type,
+        doc_number=document_data.doc_number,
+        doc_date_start=document_data.doc_date_start,
+        doc_date_end=document_data.doc_date_end,
+        doc_image_id=document_data.doc_image_id,
+    )
+    document = document_service.create_document(document_create)
+
+    saved_materials: List[schema.Material] = []
+    for material_data in materials_data:
+        material_create = schema.MaterialCreate(
+            name=material_data.name,
+            okpd=material_data.okpd,
+            amount=material_data.amount,
+            uom=material_data.uom,
+            to_be_certified=material_data.to_be_certified,
+            certificate=material_data.certificate,
+            doc_id=document.document_id,
+        )
+        material = material_service.create_material(material_create)
+        saved_materials.append(schema.Material.model_validate(material))
+
+    response = schema.PhotoProcessingResponse(
+        document=schema.Document.model_validate(document),
+        materials=saved_materials,
+    )
+    return response

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from handlers.materials import router as materials_router
 from handlers.objects import router as objects_router
 from handlers.statuses import router as statuses_router
 from handlers.subobjects import router as subobjects_router
+from handlers.others import router as others_router
 from service.db.db import create_tables
 
 create_tables()
@@ -23,6 +24,7 @@ app.include_router(incidents_router)
 app.include_router(documents_router)
 app.include_router(materials_router)
 app.include_router(statuses_router)
+app.include_router(others_router)
 
 
 @app.get("/")

--- a/backend/service/db/schema.py
+++ b/backend/service/db/schema.py
@@ -216,6 +216,11 @@ class Material(MaterialBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PhotoProcessingResponse(BaseModel):
+    document: Document
+    materials: list[Material]
+
+
 # Схемы для обновления (все поля опциональны)
 class UserUpdate(BaseModel):
     name: Optional[str] = None
@@ -335,6 +340,7 @@ __all__ = [
     "MaterialCreate",
     "Material",
     "MaterialUpdate",
+    "PhotoProcessingResponse",
     "UserUpdate",
     "LoginRequest",
     "TokenResponse",

--- a/backend/service/others/photo_client.py
+++ b/backend/service/others/photo_client.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import List, Tuple
+from uuid import uuid4
+
+from service.db import schema
+
+
+def analyze_photo(image_bytes: bytes) -> Tuple[schema.DocumentBase, List[schema.MaterialBase]]:
+    """Mock photo analysis service that returns document and material metadata."""
+
+    today = date.today()
+    document_data = schema.DocumentBase(
+        doc_type=schema.DocTypeEnum.TTN,
+        doc_number=f"DOC-{uuid4().hex[:8].upper()}",
+        doc_date_start=today,
+        doc_date_end=today + timedelta(days=30),
+        doc_image_id=uuid4().hex,
+    )
+
+    materials_data = [
+        schema.MaterialBase(
+            name="Generic Construction Material",
+            okpd="12.34.56",
+            amount=100.0,
+            uom="kg",
+            to_be_certified=True,
+            certificate="Generated certificate data",
+        )
+    ]
+
+    return document_data, materials_data


### PR DESCRIPTION
## Summary
- add an `others` router that accepts photo uploads, forwards them to a mock analyzer, and persists returned document/material data
- create a mock photo client that generates document and material metadata for testing the integration
- expose a response schema for photo processing results and register the new router in the FastAPI app

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_b_68d7dc6f73b083278c8bd9de7c2656ec