### PR TITLE
Add mock video processing workflow for inspector checks

### DIFF
--- a/backend/services/db/schema.py
+++ b/backend/services/db/schema.py
@@ -221,6 +221,11 @@ class PhotoProcessingResponse(BaseModel):
     materials: list[Material]
 
 
+class VideoProcessingResponse(BaseModel):
+    check: Check
+    incidents: list[Incident]
+
+
 # Схемы для обновления (все поля опциональны)
 class UserUpdate(BaseModel):
     name: Optional[str] = None

--- a/backend/services/others/video_client.py
+++ b/backend/services/others/video_client.py
@@ -1,0 +1,34 @@
+"""Stub client for processing inspection videos."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from services.db import schema
+
+
+def analyze_video(video_bytes: bytes) -> Tuple[schema.CheckBase, List[schema.IncidentBase]]:
+    """Mock video analysis that returns check and incident metadata.
+
+    This function pretends to forward the provided video to an external
+    detection service. Until the real integration is implemented we return
+    deterministic metadata that can be stored in the database.
+    """
+
+    check_data = schema.CheckBase(
+        info="Automatically generated inspection from video",
+        location="Video stream location",
+        status_check=schema.CheckStatusEnum.INCIDENT,
+    )
+
+    incidents_data = [
+        schema.IncidentBase(
+            photo="video_frame_reference",
+            incident_status=True,
+            incident_info="Potential safety violation detected in the video",
+            prescription_type=schema.PrescriptionTypeEnum.TYPE_1,
+        )
+    ]
+
+    return check_data, incidents_data
+


### PR DESCRIPTION
## Summary
- add an inspector-only video processing endpoint that validates input, calls the stub analyzer and persists checks and incidents
- define a video processing response schema and implement a mock video analyzer client

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7ef2b96a8832780f8bb320d18944a