### PR TITLE
Add filtering and pagination to related entity listings

### DIFF
--- a/backend/handlers/documents.py
+++ b/backend/handlers/documents.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from sqlalchemy.orm import Session
 
 from services.db import schema
@@ -22,10 +22,15 @@ def create_document(
 
 
 @router.get("/", response_model=List[schema.Document])
-def list_documents(db: Session = Depends(get_db)) -> List[schema.Document]:
+def list_documents(
+    object_id: int = Query(..., ge=1),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+) -> List[schema.Document]:
     # все проверки и офсет с лимитами, так же админу выдается все, а остальные если привязаны
     service = DocumentService(db)
-    documents = service.list_documents()
+    documents = service.list_documents(object_id=object_id, limit=limit, offset=offset)
     return [schema.Document.model_validate(item) for item in documents]
 
 

--- a/backend/handlers/incidents.py
+++ b/backend/handlers/incidents.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from services.db import schema
@@ -20,9 +20,14 @@ def create_incident(
 
 
 @router.get("/", response_model=List[schema.Incident])
-def list_incidents(db: Session = Depends(get_db)) -> List[schema.Incident]:
+def list_incidents(
+    check_id: int = Query(..., ge=1),
+    limit: int = Query(100, ge=1),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+) -> List[schema.Incident]:
     service = IncidentService(db)
-    incidents = service.list_incidents()
+    incidents = service.list_incidents(check_id=check_id, limit=limit, offset=offset)
     return [schema.Incident.model_validate(item) for item in incidents]
 
 

--- a/backend/services/db/schema.py
+++ b/backend/services/db/schema.py
@@ -1,7 +1,7 @@
 import enum
 from enum import Enum
 from datetime import date, datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -166,6 +166,11 @@ class Incident(IncidentBase):
 
 
 IncidentResponse = Incident
+
+
+class SubObjectListResponse(BaseModel):
+    object: Object
+    subobjects: List[SubObject]
 
 
 class DocumentBase(BaseModel):

--- a/backend/services/db/service.py
+++ b/backend/services/db/service.py
@@ -194,9 +194,17 @@ class SubObjectService:
         return subobject
 
     def list_subobjects(
-            self, *, limit: int, offset: int, role: schema.RoleEnum, user_id: int
+            self,
+            *,
+            object_id: int,
+            limit: int,
+            offset: int,
+            role: schema.RoleEnum,
+            user_id: int,
     ) -> List[model.SubObject]:
-        query = self._session.query(model.SubObject)
+        query = self._session.query(model.SubObject).filter(
+            model.SubObject.object_id == object_id
+        )
 
         if role in (schema.RoleEnum.INSPECTOR, schema.RoleEnum.CONTRACTOR):
             query = query.join(
@@ -283,8 +291,18 @@ class CheckService:
         self._session.refresh(check)
         return check
 
-    def list_checks(self, *, role: schema.RoleEnum, user_id: int) -> List[model.Check]:
-        query = self._session.query(model.Check)
+    def list_checks(
+            self,
+            *,
+            subobject_id: int,
+            limit: int,
+            offset: int,
+            role: schema.RoleEnum,
+            user_id: int,
+    ) -> List[model.Check]:
+        query = self._session.query(model.Check).filter(
+            model.Check.subobject_id == subobject_id
+        )
 
         if role == schema.RoleEnum.INSPECTOR:
             query = (
@@ -295,7 +313,7 @@ class CheckService:
                 .filter(model.Object.inspector_id == user_id)
             )
 
-        return query.all()
+        return query.offset(offset).limit(limit).all()
 
     def get_check(self, check_id: int) -> Optional[model.Check]:
         return (
@@ -361,8 +379,16 @@ class IncidentService:
         self._session.refresh(incident)
         return incident
 
-    def list_incidents(self) -> List[model.Incident]:
-        return self._session.query(model.Incident).all()
+    def list_incidents(
+            self, *, check_id: int, limit: int, offset: int
+    ) -> List[model.Incident]:
+        return (
+            self._session.query(model.Incident)
+            .filter(model.Incident.check_id == check_id)
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
 
     def get_incident(self, incident_id: int) -> Optional[model.Incident]:
         return (
@@ -427,8 +453,16 @@ class DocumentService:
         self._session.refresh(document)
         return document
 
-    def list_documents(self) -> List[model.Document]:
-        return self._session.query(model.Document).all()
+    def list_documents(
+            self, *, object_id: int, limit: int, offset: int
+    ) -> List[model.Document]:
+        return (
+            self._session.query(model.Document)
+            .filter(model.Document.object_id == object_id)
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
 
     def get_document(self, document_id: int) -> Optional[model.Document]:
         return (


### PR DESCRIPTION
## Summary
- require an object_id when listing subobjects and include parent object details in the response
- add mandatory identifiers and pagination to list endpoints for checks, documents, and incidents
- update schema and service layers to support the new filters and limits

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d96d8faba08327897a2974e6840dcc